### PR TITLE
HOTFIX: 영속화된 시간값을 읽을 때 외부 환경에 영향 받지 않도록 애플리케이션 TimeZone 설정

### DIFF
--- a/src/main/java/podo/odeego/OdeegoApplication.java
+++ b/src/main/java/podo/odeego/OdeegoApplication.java
@@ -1,8 +1,15 @@
 package podo.odeego;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
+import javax.annotation.PostConstruct;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import podo.odeego.domain.util.TimeUtils;
 
 @EnableJpaAuditing
 @SpringBootApplication
@@ -12,4 +19,9 @@ public class OdeegoApplication {
 		SpringApplication.run(OdeegoApplication.class, args);
 	}
 
+	@PostConstruct
+	public void setApplicationTimeZoneAndLocale() {
+		TimeZone.setDefault(TimeUtils.getDefaultTimeZone());
+		Locale.setDefault(Locale.KOREA);
+	}
 }

--- a/src/main/java/podo/odeego/domain/util/TimeUtils.java
+++ b/src/main/java/podo/odeego/domain/util/TimeUtils.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.TimeZone;
 
 public class TimeUtils {
 
@@ -16,6 +17,10 @@ public class TimeUtils {
 	public static LocalDateTime getCurrentSeoulTime() {
 		return ZonedDateTime.now(ZoneId.of(ZONE_ASIA_SEOUL))
 			.toLocalDateTime();
+	}
+
+	public static TimeZone getDefaultTimeZone() {
+		return TimeZone.getTimeZone(ZONE_ASIA_SEOUL);
 	}
 
 	public static Duration toDuration(LocalTime localTime) {


### PR DESCRIPTION
### Ticket

<br>


### 개발 내용
> 수정 or 추가, 개발된 내용에 대해서 1줄로 간단히 작성합니다.  

RDS 에 저장된 시간 값이 애플리케이션 동작 시 자동으로 EC2 환경에 영향받는 것을 방지합니다.

### 리마인더
- [ ] 본인의 로컬에서 정상 동작하는지 확인해주세요.
- [ ] 최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
- [ ] **API**가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
- [ ] **Conflict**가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
- [ ] **컨벤션(코드, 커밋 메시지)** 을 잘 지켰는지 확인해주세요.
- [ ] application.yml 이 PR에 포함되면 안 됩니다. .gitigonre를 확인해주세요.
- [ ] 코멘트로 작성한 코드에 대해 간단하게 설명해주세요.  

<br>

### 코드리뷰 룰
- R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
- C(Comment): 웬만하면 고려해주시면 좋겠습니다.
- A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.
