### PR TITLE
[ODE-76] 회원 탈퇴 API

### DIFF
--- a/src/main/java/podo/odeego/domain/member/service/MemberService.java
+++ b/src/main/java/podo/odeego/domain/member/service/MemberService.java
@@ -77,4 +77,11 @@ public class MemberService {
 			throw new DefaultStationNotExistsException(e.getMessage());
 		}
 	}
+
+	public void leave(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberNotFoundException(
+				"Cannot find Member for memberId=%d.".formatted(memberId)));
+		memberRepository.delete(member);
+	}
 }

--- a/src/main/java/podo/odeego/domain/member/service/MemberService.java
+++ b/src/main/java/podo/odeego/domain/member/service/MemberService.java
@@ -55,7 +55,6 @@ public class MemberService {
 
 	public void signUp(Long memberId, MemberSignUpRequest signUpRequest) {
 		verifyUniqueNickname(signUpRequest.nickname());
-		verifyStationExists(signUpRequest.defaultStationName());
 
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new MemberNotFoundException(

--- a/src/main/java/podo/odeego/web/api/member/MemberTestApi.java
+++ b/src/main/java/podo/odeego/web/api/member/MemberTestApi.java
@@ -1,0 +1,36 @@
+package podo.odeego.web.api.member;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import podo.odeego.domain.member.dto.MemberJoinResponse;
+import podo.odeego.domain.member.service.MemberService;
+
+@RestController
+public class MemberTestApi {
+
+	private final MemberService memberService;
+
+	public MemberTestApi(MemberService memberService) {
+		this.memberService = memberService;
+	}
+
+	@PostMapping("/api/test/members")
+	public ResponseEntity<MemberJoinResponse> create(
+		@RequestParam String nickname
+	) {
+		Long joinedMemberId = memberService.join(nickname);
+
+		URI uri = UriComponentsBuilder.fromPath("/api/test/dummy-member/{memberId}")
+			.buildAndExpand(joinedMemberId)
+			.toUri();
+
+		return ResponseEntity.created(uri)
+			.build();
+	}
+}

--- a/src/main/java/podo/odeego/web/api/member/MemberTestApi.java
+++ b/src/main/java/podo/odeego/web/api/member/MemberTestApi.java
@@ -3,7 +3,9 @@ package podo.odeego.web.api.member;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -12,6 +14,7 @@ import podo.odeego.domain.member.dto.MemberJoinResponse;
 import podo.odeego.domain.member.service.MemberService;
 
 @RestController
+@RequestMapping("/api/test/members")
 public class MemberTestApi {
 
 	private final MemberService memberService;
@@ -20,7 +23,7 @@ public class MemberTestApi {
 		this.memberService = memberService;
 	}
 
-	@PostMapping("/api/test/members")
+	@PostMapping
 	public ResponseEntity<MemberJoinResponse> create(
 		@RequestParam String nickname
 	) {
@@ -32,5 +35,13 @@ public class MemberTestApi {
 
 		return ResponseEntity.created(uri)
 			.build();
+	}
+
+	@DeleteMapping("/leave")
+	public ResponseEntity<Void> leave(
+		@RequestParam(name = "member-id") Long memberId
+	) {
+		memberService.leave(memberId);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/podo/odeego/web/api/member/v1/MemberApi.java
+++ b/src/main/java/podo/odeego/web/api/member/v1/MemberApi.java
@@ -2,6 +2,7 @@ package podo.odeego.web.api.member.v1;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,6 +39,14 @@ public class MemberApi {
 		@RequestBody MemberSignUpRequest request
 	) {
 		memberService.signUp(principal.memberId(), request);
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/leave")
+	public ResponseEntity<Void> leave(
+		@AuthenticationPrincipal JwtAuthenticationPrincipal principal
+	) {
+		memberService.leave(principal.memberId());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/podo/odeego/web/api/member/v1/MemberApi.java
+++ b/src/main/java/podo/odeego/web/api/member/v1/MemberApi.java
@@ -1,25 +1,22 @@
-package podo.odeego.web.api.member;
-
-import java.net.URI;
+package podo.odeego.web.api.member.v1;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import podo.odeego.domain.member.dto.MemberDefaultStationGetResponse;
-import podo.odeego.domain.member.dto.MemberJoinResponse;
 import podo.odeego.domain.member.dto.MemberSignUpRequest;
 import podo.odeego.domain.member.service.MemberFindService;
 import podo.odeego.domain.member.service.MemberService;
 import podo.odeego.web.security.jwt.JwtAuthenticationPrincipal;
 
 @RestController
+@RequestMapping("/api/v1/members")
 public class MemberApi {
 
 	private final MemberService memberService;
@@ -30,26 +27,12 @@ public class MemberApi {
 		this.memberFindService = memberFindService;
 	}
 
-	@PostMapping("/api/test/members")
-	public ResponseEntity<MemberJoinResponse> create(
-		@RequestParam String nickname
-	) {
-		Long joinedMemberId = memberService.join(nickname);
-
-		URI uri = UriComponentsBuilder.fromPath("/api/test/dummy-member/{memberId}")
-			.buildAndExpand(joinedMemberId)
-			.toUri();
-
-		return ResponseEntity.created(uri)
-			.build();
-	}
-
-	@GetMapping("/api/v1/members/default-station")
+	@GetMapping("/default-station")
 	public ResponseEntity<MemberDefaultStationGetResponse> getDefaultStation(@RequestParam("memberId") Long memberId) {
 		return ResponseEntity.ok(memberFindService.findDefaultStation(memberId));
 	}
 
-	@PatchMapping("/api/v1/members/sign-up")
+	@PatchMapping("/sign-up")
 	public ResponseEntity<Void> signUp(
 		@AuthenticationPrincipal JwtAuthenticationPrincipal principal,
 		@RequestBody MemberSignUpRequest request

--- a/src/test/java/podo/odeego/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/podo/odeego/domain/member/service/MemberServiceTest.java
@@ -16,6 +16,7 @@ import podo.odeego.domain.member.dto.MemberSignUpRequest;
 import podo.odeego.domain.member.entity.Member;
 import podo.odeego.domain.member.entity.MemberType;
 import podo.odeego.domain.member.exception.MemberNicknameDuplicatedException;
+import podo.odeego.domain.member.exception.MemberNotFoundException;
 import podo.odeego.domain.member.repository.MemberRepository;
 import podo.odeego.domain.station.entity.Station;
 import podo.odeego.domain.station.repository.StationRepository;
@@ -85,14 +86,51 @@ class MemberServiceTest {
 	public void signUpFailedByDefaultStationName() {
 		//given
 		Member member = Member.ofNickname("닉네임", "testProvider", "1234");
-		Member existMember = memberRepository.save(member);
+		Member savedMember = memberRepository.save(member);
 
 		//when
 		MemberSignUpRequest signUpRequest = new MemberSignUpRequest("닉네임", "없는역없는역");
 
 		//then
-		assertThatThrownBy(() -> memberService.signUp(existMember.id(), signUpRequest))
+		assertThatThrownBy(() -> memberService.signUp(savedMember.id(), signUpRequest))
 			.isInstanceOf(MemberNicknameDuplicatedException.class)
 			.hasMessage("Cannot sign up with duplicated nickname: %s".formatted("닉네임"));
+	}
+
+	@Test
+	@DisplayName("올바른 회원 ID로 회원 탈퇴를 할 경우 성공합니다.")
+	public void leaveSuccess() {
+		//given
+		stationRepository.save(
+			new Station("강남역", "서울특별시", 123.123, 123.123, "2호선"));
+		MemberJoinResponse joinedMember = memberService.join("testProvider", "1234", "testUrl");
+		MemberSignUpRequest signUpRequest = new MemberSignUpRequest("닉네임", "강남역");
+		memberService.signUp(joinedMember.id(), signUpRequest);
+
+		//when
+		memberService.leave(joinedMember.id());
+
+		//then
+		int actual = memberRepository.findAll().size();
+		assertThat(actual).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 회원 ID로 회원 탈퇴를 할 경우 실패합니다.")
+	public void leaveFailedById() {
+		//given
+		stationRepository.save(
+			new Station("강남역", "서울특별시", 123.123, 123.123, "2호선"));
+		MemberJoinResponse joinedMember = memberService.join("testProvider", "1234", "testUrl");
+		MemberSignUpRequest signUpRequest = new MemberSignUpRequest("닉네임", "강남역");
+		memberService.signUp(joinedMember.id(), signUpRequest);
+
+		//when
+		Long wrongId = 123234345456L;
+
+		//then
+		assertThatThrownBy(() -> memberService.leave(wrongId))
+			.isInstanceOf(MemberNotFoundException.class)
+			.hasMessage("Cannot find Member for memberId=%d.".formatted(wrongId));
 	}
 }

--- a/src/test/java/podo/odeego/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/podo/odeego/domain/member/service/MemberServiceTest.java
@@ -82,22 +82,6 @@ class MemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("DB상에 존재하지 않는 역을 추가정보로 입력한 경우 실패합니다")
-	public void signUpFailedByDefaultStationName() {
-		//given
-		Member member = Member.ofNickname("닉네임", "testProvider", "1234");
-		Member savedMember = memberRepository.save(member);
-
-		//when
-		MemberSignUpRequest signUpRequest = new MemberSignUpRequest("닉네임", "없는역없는역");
-
-		//then
-		assertThatThrownBy(() -> memberService.signUp(savedMember.id(), signUpRequest))
-			.isInstanceOf(MemberNicknameDuplicatedException.class)
-			.hasMessage("Cannot sign up with duplicated nickname: %s".formatted("닉네임"));
-	}
-
-	@Test
 	@DisplayName("올바른 회원 ID로 회원 탈퇴를 할 경우 성공합니다.")
 	public void leaveSuccess() {
 		//given


### PR DESCRIPTION
### Ticket
- Jira 티켓: [ODE-76]  

<br>


### 개발 내용
> 수정 or 추가, 개발된 내용에 대해서 1줄로 간단히 작성합니다.  
회원 탈퇴 API를 구현하였습니다. 추가로 query parameter를 사용하는 테스트용 API도 구현해놓았습니다.

회원 엔티티를 보니 `Group` 엔티티와 `연관관계`가 있는 것으로 확인했는데, 이 부분은 제가 설계한 부분이 아니다보니
회원이 탈퇴할 때 `속해있는 Group에 회원 정보를 없애야할지 말아야할지`를 혼자 결정할 수 없었습니다.
Group 도메인을 맡으신 분이 의견 주시죠!

<br>

### 리마인더
- [ ] 본인의 로컬에서 정상 동작하는지 확인해주세요.
- [ ] 최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
- [ ] **API**가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
- [ ] **Conflict**가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
- [ ] **컨벤션(코드, 커밋 메시지)** 을 잘 지켰는지 확인해주세요.
- [ ] application.yml 이 PR에 포함되면 안 됩니다. .gitigonre를 확인해주세요.
- [ ] 코멘트로 작성한 코드에 대해 간단하게 설명해주세요.  

<br>

### 코드리뷰 룰
- R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
- C(Comment): 웬만하면 고려해주시면 좋겠습니다.
- A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.


[ODE-76]: https://devcourse-podo.atlassian.net/browse/ODE-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ