### PR TITLE
[ODE-81] 장소 조회 시 응답에 이미지 URL을 포함합니다

### DIFF
--- a/src/main/java/podo/odeego/domain/place/dto/PlaceImageUrl.java
+++ b/src/main/java/podo/odeego/domain/place/dto/PlaceImageUrl.java
@@ -1,0 +1,24 @@
+package podo.odeego.domain.place.dto;
+
+import java.util.List;
+
+import podo.odeego.domain.place.entity.PlaceImage;
+
+public class PlaceImageUrl {
+
+	private String url;
+
+	private PlaceImageUrl(String url) {
+		this.url = url;
+	}
+
+	public static List<PlaceImageUrl> from(List<PlaceImage> images) {
+		return images.stream()
+			.map(image -> new PlaceImageUrl(image.getUrl()))
+			.toList();
+	}
+
+	public String getUrl() {
+		return url;
+	}
+}

--- a/src/main/java/podo/odeego/domain/place/dto/PlaceImageUrl.java
+++ b/src/main/java/podo/odeego/domain/place/dto/PlaceImageUrl.java
@@ -4,21 +4,13 @@ import java.util.List;
 
 import podo.odeego.domain.place.entity.PlaceImage;
 
-public class PlaceImageUrl {
-
-	private String url;
-
-	private PlaceImageUrl(String url) {
-		this.url = url;
-	}
+public record PlaceImageUrl(
+	String url
+) {
 
 	public static List<PlaceImageUrl> from(List<PlaceImage> images) {
 		return images.stream()
 			.map(image -> new PlaceImageUrl(image.getUrl()))
 			.toList();
-	}
-
-	public String getUrl() {
-		return url;
 	}
 }

--- a/src/main/java/podo/odeego/domain/place/dto/PlaceQueryResponse.java
+++ b/src/main/java/podo/odeego/domain/place/dto/PlaceQueryResponse.java
@@ -1,5 +1,6 @@
 package podo.odeego.domain.place.dto;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -9,14 +10,20 @@ public class PlaceQueryResponse {
 
 	private String businessName;
 	private String address;
+	private List<PlaceImageUrl> images;
 
 	public PlaceQueryResponse(String businessName, String address) {
+		this(businessName, address, new ArrayList<>());
+	}
+
+	public PlaceQueryResponse(String businessName, String address, List<PlaceImageUrl> images) {
 		this.businessName = businessName;
 		this.address = address;
+		this.images = images;
 	}
 
 	public static PlaceQueryResponse from(Place place) {
-		return new PlaceQueryResponse(place.name(), place.address());
+		return new PlaceQueryResponse(place.name(), place.address(), PlaceImageUrl.from(place.images()));
 	}
 
 	public static List<PlaceQueryResponse> from(List<Place> places) {
@@ -32,6 +39,10 @@ public class PlaceQueryResponse {
 
 	public String getAddress() {
 		return address;
+	}
+
+	public List<PlaceImageUrl> getImages() {
+		return images;
 	}
 
 	@Override

--- a/src/main/java/podo/odeego/domain/place/entity/Place.java
+++ b/src/main/java/podo/odeego/domain/place/entity/Place.java
@@ -4,6 +4,7 @@ import static javax.persistence.CascadeType.*;
 import static javax.persistence.EnumType.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.Column;
@@ -90,5 +91,9 @@ public class Place {
 
 	public String stationName() {
 		return stationName;
+	}
+
+	public List<PlaceImage> images() {
+		return Collections.unmodifiableList(this.images);
 	}
 }


### PR DESCRIPTION
### Ticket
- Jira 티켓: [ODE-81]  

<br>


### 개발 내용
> 수정 or 추가, 개발된 내용에 대해서 1줄로 간단히 작성합니다.  

장소 조회 시 응답에 이미지 URL을 포함하기 위해 기존의 Response DTO에 이미지를 표현하는 필드를 추가하였습니다.

<br> 

### 리마인더
- [x] 본인의 로컬에서 정상 동작하는지 확인해주세요.
- [x] 최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
- [x] **API**가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
- [x] **Conflict**가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
- [x] **컨벤션(코드, 커밋 메시지)** 을 잘 지켰는지 확인해주세요.
- [x] application.yml 이 PR에 포함되면 안 됩니다. .gitigonre를 확인해주세요.
- [x] 코멘트로 작성한 코드에 대해 간단하게 설명해주세요.  

<br>

### 코드리뷰 룰
- R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
- C(Comment): 웬만하면 고려해주시면 좋겠습니다.
- A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.


[ODE-81]: https://devcourse-podo.atlassian.net/browse/ODE-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ