### PR TITLE
[ODE-117] 회원 탈퇴 시 연관된 그룹 정보도 같이 삭제하도록 변경

### DIFF
--- a/src/main/java/podo/odeego/domain/group/entity/Group.java
+++ b/src/main/java/podo/odeego/domain/group/entity/Group.java
@@ -54,7 +54,7 @@ public class Group extends BaseTime {
 	private LocalTime validTime;
 
 	@OneToMany(mappedBy = "group", cascade = {REMOVE, PERSIST, MERGE})
-	private List<GroupMember> groupMembers = new ArrayList<>();
+	private final List<GroupMember> groupMembers = new ArrayList<>();
 
 	protected Group() {
 	}
@@ -77,6 +77,10 @@ public class Group extends BaseTime {
 
 		groupMember.assignGroup(this);
 		this.groupMembers.add(groupMember);
+	}
+
+	public void removeGroupMember(GroupMember groupMember) {
+		this.groupMembers.remove(groupMember);
 	}
 
 	public void defineHostStation(Station station) {
@@ -120,14 +124,17 @@ public class Group extends BaseTime {
 	}
 
 	public void verifyHostMatches(Member member) {
-		GroupMember host = findHost();
-
-		if (!host.isMemberIdMatches(member.id())) {
+		if (!isGroupHost(member)) {
 			throw new GroupHostNotMatchException(
-				"Group host not matched. Group '%s''s hostId is '%d' but access memberId is '%d'."
-					.formatted(this.id.toString(), host.getMemberId(), member.id())
+				"Group host not matched. Member for memberId=%d is not host of Group for groupId=%s."
+					.formatted(member.id(), this.id.toString())
 			);
 		}
+	}
+
+	public boolean isGroupHost(Member member) {
+		GroupMember host = findHost();
+		return host.isMemberIdMatches(member.id());
 	}
 
 	private GroupMember findHost() {

--- a/src/main/java/podo/odeego/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/podo/odeego/domain/group/repository/GroupMemberRepository.java
@@ -1,8 +1,11 @@
 package podo.odeego.domain.group.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import podo.odeego.domain.group.entity.Group;
 import podo.odeego.domain.group.entity.GroupMember;
@@ -10,4 +13,11 @@ import podo.odeego.domain.group.entity.GroupMember;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
 	List<GroupMember> findGroupMembersByGroup(Group group);
+
+	@Query("""
+		select gm
+		from GroupMember gm
+		inner join gm.member m
+		where m.id = :memberId""")
+	Optional<GroupMember> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/podo/odeego/domain/group/repository/GroupRepository.java
+++ b/src/main/java/podo/odeego/domain/group/repository/GroupRepository.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import podo.odeego.domain.group.entity.Group;
@@ -18,5 +19,5 @@ public interface GroupRepository extends JpaRepository<Group, UUID> {
 		join fetch 	g.groupMembers
 		where g.id = :groupId
 		""")
-	Optional<Group> findFetchById(UUID groupId);
+	Optional<Group> findFetchById(@Param(value = "groupId") UUID groupId);
 }

--- a/src/main/java/podo/odeego/domain/group/service/GroupRemoveService.java
+++ b/src/main/java/podo/odeego/domain/group/service/GroupRemoveService.java
@@ -1,11 +1,14 @@
 package podo.odeego.domain.group.service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import podo.odeego.domain.group.entity.Group;
+import podo.odeego.domain.group.entity.GroupMember;
+import podo.odeego.domain.group.repository.GroupMemberRepository;
 import podo.odeego.domain.group.repository.GroupRepository;
 import podo.odeego.domain.member.entity.Member;
 import podo.odeego.domain.member.service.MemberFindService;
@@ -14,18 +17,21 @@ import podo.odeego.domain.member.service.MemberFindService;
 @Transactional
 public class GroupRemoveService {
 
-	private final MemberFindService memberFindService;
 	private final GroupRepository groupRepository;
+	private final GroupMemberRepository groupMemberRepository;
 	private final GroupQueryService groupQueryService;
+	private final MemberFindService memberFindService;
 
 	public GroupRemoveService(
-		MemberFindService memberFindService,
 		GroupRepository groupRepository,
-		GroupQueryService groupQueryService
+		GroupMemberRepository groupMemberRepository,
+		GroupQueryService groupQueryService,
+		MemberFindService memberFindService
 	) {
-		this.memberFindService = memberFindService;
 		this.groupRepository = groupRepository;
+		this.groupMemberRepository = groupMemberRepository;
 		this.groupQueryService = groupQueryService;
+		this.memberFindService = memberFindService;
 	}
 
 	public void remove(Long memberId, UUID groupId) {
@@ -35,5 +41,22 @@ public class GroupRemoveService {
 		findGroup.verifyHostMatches(findMember);
 
 		groupRepository.delete(findGroup);
+	}
+
+	public void deleteGroupInfoByParticipantType(Long memberId) {
+		Optional<GroupMember> possibleGroupMember = groupMemberRepository.findByMemberId(memberId);
+		possibleGroupMember.ifPresent(this::deleteGroupInfoByParticipantType);
+	}
+
+	private void deleteGroupInfoByParticipantType(GroupMember groupMember) {
+		Group participatingGroup = groupMember.group();
+
+		if (groupMember.isHost()) {
+			groupRepository.delete(participatingGroup);
+			return;
+		}
+
+		participatingGroup.removeGroupMember(groupMember);
+		groupMemberRepository.delete(groupMember);
 	}
 }

--- a/src/main/java/podo/odeego/domain/member/service/MemberService.java
+++ b/src/main/java/podo/odeego/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import podo.odeego.domain.group.service.GroupRemoveService;
 import podo.odeego.domain.member.dto.MemberJoinResponse;
 import podo.odeego.domain.member.dto.MemberSignUpRequest;
 import podo.odeego.domain.member.entity.Member;
@@ -20,9 +21,17 @@ public class MemberService {
 	private final Logger log = LoggerFactory.getLogger(getClass());
 
 	private final MemberRepository memberRepository;
+	private final MemberFindService memberFindService;
+	private final GroupRemoveService groupRemoveService;
 
-	public MemberService(MemberRepository memberRepository) {
+	public MemberService(
+		MemberRepository memberRepository,
+		MemberFindService memberFindService,
+		GroupRemoveService groupRemoveService
+	) {
 		this.memberRepository = memberRepository;
+		this.memberFindService = memberFindService;
+		this.groupRemoveService = groupRemoveService;
 	}
 
 	public MemberJoinResponse join(String profileImageUrl, String provider, String providerId) {
@@ -64,9 +73,10 @@ public class MemberService {
 	}
 
 	public void leave(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new MemberNotFoundException(
-				"Cannot find Member for memberId=%d.".formatted(memberId)));
-		memberRepository.delete(member);
+		Member findMember = memberFindService.findById(memberId);
+
+		groupRemoveService.deleteGroupInfoByParticipantType(memberId);
+
+		memberRepository.delete(findMember);
 	}
 }

--- a/src/test/java/podo/odeego/config/TestConfig.java
+++ b/src/test/java/podo/odeego/config/TestConfig.java
@@ -57,11 +57,12 @@ public class TestConfig {
 
 	@Bean
 	public GroupRemoveService groupRemoveService(
-		MemberFindService memberFindService,
 		GroupRepository groupRepository,
-		GroupQueryService groupQueryService
+		GroupMemberRepository groupMemberRepository,
+		GroupQueryService groupQueryService,
+		MemberFindService memberFindService
 	) {
-		return new GroupRemoveService(memberFindService, groupRepository, groupQueryService);
+		return new GroupRemoveService(groupRepository, groupMemberRepository, groupQueryService, memberFindService);
 	}
 
 	@Bean

--- a/src/test/java/podo/odeego/config/TestConfig.java
+++ b/src/test/java/podo/odeego/config/TestConfig.java
@@ -40,9 +40,15 @@ public class TestConfig {
 
 	@Bean
 	public MemberService memberService(
-		MemberRepository memberRepository
+		MemberRepository memberRepository,
+		MemberFindService memberFindService,
+		GroupRemoveService groupRemoveService
 	) {
-		return new MemberService(memberRepository);
+		return new MemberService(
+			memberRepository,
+			memberFindService,
+			groupRemoveService
+		);
 	}
 
 	// Group

--- a/src/test/java/podo/odeego/domain/group/service/GroupRemoveServiceTest.java
+++ b/src/test/java/podo/odeego/domain/group/service/GroupRemoveServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
 
+import javax.persistence.EntityManager;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +20,7 @@ import podo.odeego.domain.group.entity.GroupCapacity;
 import podo.odeego.domain.group.entity.GroupMember;
 import podo.odeego.domain.group.entity.ParticipantType;
 import podo.odeego.domain.group.exception.GroupHostNotMatchException;
+import podo.odeego.domain.group.repository.GroupMemberRepository;
 import podo.odeego.domain.group.repository.GroupRepository;
 import podo.odeego.domain.member.entity.Member;
 import podo.odeego.domain.member.repository.MemberRepository;
@@ -34,7 +37,13 @@ class GroupRemoveServiceTest {
 	private GroupRepository groupRepository;
 
 	@Autowired
+	private GroupMemberRepository groupMemberRepository;
+
+	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private EntityManager em;
 
 	@Test
 	@DisplayName("그룹의 호스트만 그룹을 삭제할 수 있다.")
@@ -68,5 +77,55 @@ class GroupRemoveServiceTest {
 		// when & then
 		assertThatThrownBy(() -> groupRemoveService.remove(nonGroupHost.id(), savedGroup.id()))
 			.isInstanceOf(GroupHostNotMatchException.class);
+	}
+
+	@Test
+	@DisplayName("호스트로 참여한 회원이 그룹 정보를 삭제할 때, 그룹과 그룹에 속해있는 그룹멤버가 모두 삭제된다.")
+	void group_should_be_deleted_if_member_participates_as_host() {
+		// given
+		Member hostMember =
+			memberRepository.save(Member.ofNickname("host", "provider", "providerId"));
+
+		GroupMember groupMemberAsHost = GroupMember.newInstance(hostMember, ParticipantType.HOST);
+		Group group = new Group(new GroupCapacity(GroupCapacity.MAX_CAPACITY), Group.GROUP_VALID_TIME);
+		group.addGroupMember(groupMemberAsHost);
+		groupRepository.save(group);
+
+		// when
+		groupRemoveService.deleteGroupInfoByParticipantType(hostMember.id());
+
+		// then
+		int actualAllGroupSize = groupRepository.findAll()
+			.size();
+		assertThat(actualAllGroupSize).isZero();
+
+		int actualAllGroupMemberSize = groupMemberRepository.findAll()
+			.size();
+		assertThat(actualAllGroupMemberSize).isZero();
+	}
+
+	@Test
+	@DisplayName("게스트로 참여한 회원이 그룹 정보를 삭제할 때, 그룹은 삭제되지 않고 그룹 멤버만 삭제된다.")
+	void only_groupMember_is_deleted_if_member_participates_as_guest() {
+		// given
+		Member guestMember =
+			memberRepository.save(Member.ofNickname("guest", "provider", "providerId"));
+
+		GroupMember groupMemberAsGuest = GroupMember.newInstance(guestMember, ParticipantType.GUEST);
+		Group group = new Group(new GroupCapacity(GroupCapacity.MAX_CAPACITY), Group.GROUP_VALID_TIME);
+		group.addGroupMember(groupMemberAsGuest);
+		groupRepository.save(group);
+
+		// when
+		groupRemoveService.deleteGroupInfoByParticipantType(guestMember.id());
+
+		// then
+		int actualAllGroupSize = groupRepository.findAll()
+			.size();
+		assertThat(actualAllGroupSize).isNotZero();
+
+		int actualAllGroupMemberSize = groupMemberRepository.findAll()
+			.size();
+		assertThat(actualAllGroupMemberSize).isZero();
 	}
 }


### PR DESCRIPTION
### Ticket
- Jira 티켓: [ODE-117]  

<br>

### 개발 내용
> 수정 or 추가, 개발된 내용에 대해서 1줄로 간단히 작성합니다.  

- 회원 탈퇴 시, 회원의 그룹 참여 유형에 따라 그룹 관련 엔티티를 삭제합니다.
  - 그룹에 `호스트`로 참여시, 그룹과 그룹에 속한 그룹멤버를 전부 삭제합니다.
  - 그룹에 `게스트`로 참여시, 기존 그룹은 유지하고 멤버와 매핑되어있는 그룹멤버 엔티티를 삭제합니다.

<br>

### 리마인더
- [x] 본인의 로컬에서 정상 동작하는지 확인해주세요.
- [x] 최신 브랜치를 Pull 받고 PR을 요청했는지 확인해주세요.
- [x] **API**가 추가되었을 경우 테스트를 하고 PR을 올려주세요.
- [x] **Conflict**가 났을 때, UI상에서 해결하지 말고, 본인 local에서 해결해주세요.
- [x] **컨벤션(코드, 커밋 메시지)** 을 잘 지켰는지 확인해주세요.
- [x] application.yml 이 PR에 포함되면 안 됩니다. .gitigonre를 확인해주세요.
- [x] 코멘트로 작성한 코드에 대해 간단하게 설명해주세요.  

<br>

### 코드리뷰 룰
- R(Request Change): 해당 블럭은 꼭 변경해주셨으면 좋겠습니다.
- C(Comment): 웬만하면 고려해주시면 좋겠습니다.
- A(Approve): 반영해도 좋고 넘어가도 좋습니다. 혹은 사소한 의견입니다.


[ODE-117]: https://devcourse-podo.atlassian.net/browse/ODE-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ